### PR TITLE
IOTMBL-7: bblayers.conf: remove unused layers from configuration.

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -9,28 +9,16 @@ BBFILES = ""
 
 # These layers hold recipe metadata not found in OE-core, but lack any machine or distro content
 BASELAYERS ?= " \
-  ${OEROOT}/layers/meta-openembedded/meta-oe \
-  ${OEROOT}/layers/meta-openembedded/meta-gnome \
-  ${OEROOT}/layers/meta-openembedded/meta-xfce \
-  ${OEROOT}/layers/meta-openembedded/meta-initramfs \
-  ${OEROOT}/layers/meta-openembedded/meta-multimedia \
-  ${OEROOT}/layers/meta-openembedded/meta-networking \
-  ${OEROOT}/layers/meta-openembedded/meta-webserver \
-  ${OEROOT}/layers/meta-openembedded/meta-ruby \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
-  ${OEROOT}/layers/meta-openembedded/meta-perl \
+  ${OEROOT}/layers/meta-openembedded/meta-networking \
+  ${OEROOT}/layers/meta-openembedded/meta-oe \
   ${OEROOT}/layers/meta-openembedded/meta-python \
-  ${OEROOT}/layers/meta-browser \
-  ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \
-  ${OEROOT}/layers/meta-raspberrypi \
 "
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
-  ${OEROOT}/layers/meta-qcom \
-  ${OEROOT}/layers/meta-96boards \
-  ${OEROOT}/layers/meta-ti \
+  ${OEROOT}/layers/meta-raspberrypi \
 "
 
 # Add your overlay location to EXTRALAYERS
@@ -44,7 +32,6 @@ EXTRALAYERS ?= " \
 
 BBLAYERS = " \
   ${OEROOT}/layers/meta-mbl \
-  ${OEROOT}/layers/meta-rpb \
   ${BASELAYERS} \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \


### PR DESCRIPTION
The following provides further information on this commit:
- This is a backport of a master patch to the pyro branch.
- Removing the unused layers will speed up bitbake parsing
  as usused recipes will not be parsed.
- Removing the usused layers enables the default.xml to be
  simplified by removing unused projects. This will
  increase the speed of repo init and repo download operations.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>