### PR TITLE
IOTMBL52: bblayers.conf: include meta-mbl-private/conf/bblayers.conf

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -38,3 +38,6 @@ BBLAYERS = " \
   ${EXTRALAYERS} \
   ${OEROOT}/layers/openembedded-core/meta \
 "
+
+# allow meta-mbl-private to add itself to BBLAYERS, if present
+include ${OEROOT}/layers/meta-mbl-private/conf/bblayers.conf


### PR DESCRIPTION
The following provides further information on this commit:
- The armmbed/mbl-config repo currently has the following branches
  for a bblayers.conf file where BBLAYERS has the meta-mbl-private
  added:
  - arm-internal-master
  - arm-internal-pyro
  - arm-internal-rocko
- It is possible to dispense with these branches by:
  - Modifying meta-mbl/conf/bblayers.conf to include a
    meta-mbl-private/conf/bblayers.conf (if present), and
    removing layers/meta-mbl-private from BBLAYERS.
  - Adding meta-mbl-private/conf/bblayers.conf which
    adds layers/meta-mbl-private to BBLAYER.
- If the meta-mbl-private layer is not present then the
  include directive will silently fail.
- This commit contains the required mbl-config repo changes.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>

### Related PRs

https://github.com/ARMmbed/mbl-manifest/pull/35
https://github.com/ARMmbed/mbl-config/pull/10
https://github.com/ARMmbed/meta-mbl-private/pull/12