### PR TITLE
Add u-boot and firmware for broadcom WiFi/BT.

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -49,3 +49,4 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 #PRSERV_HOST = "localhost:0"
 
 ACCEPT_FSL_EULA = "1"
+MACHINE_FIRMWARE_append_mx7 += " firmware-warp7 "


### PR DESCRIPTION
Use MACHINE_FIRMWARE_append_mx7 instead of CORE_IMAGE_EXTRA_INSTALL to
avoid RPi3 image build fail.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>