### PR TITLE
Override FETCHCMD_wget

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -49,3 +49,9 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 #PRSERV_HOST = "localhost:0"
 
 ACCEPT_FSL_EULA = "1"
+
+# Override default FETCHCMD_wget with increased timeout parameters
+# -t: number of tries (default was 2)
+# -T: network timeout in seconds (default was 30)
+# The rest of the parameters are the same.
+FETCHCMD_wget = "/usr/bin/env wget -t 10 -T 90 -nv --passive-ftp --no-check-certificate"


### PR DESCRIPTION
The main purpose is to increase timeout values when downloading
packages using wget.
More specifically -t (number of tries) and -T (network timeout in
seconds) have been increased to 10 and 90 respectively.

Signed-off-by: Diego Russo <diego.russo@arm.com>