### PR TITLE
Update for rename of meta-mbl-private repository

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -39,8 +39,8 @@ BBLAYERS = " \
   ${OEROOT}/layers/openembedded-core/meta \
 "
 
-# allow meta-mbl-private to add itself to BBLAYERS, if present
-include ${OEROOT}/layers/meta-mbl-private/conf/bblayers.conf
+# allow meta-mbl-internal-extras to add itself to BBLAYERS, if present
+include ${OEROOT}/layers/meta-mbl-internal-extras/conf/bblayers.conf
 
 # allow meta-mbl-reference-apps to add itself to BBLAYERS, if present
 include ${OEROOT}/layers/meta-mbl-reference-apps/conf/bblayers.conf


### PR DESCRIPTION
For:
IOTMBL-267: Rename meta-mbl-private to meta-mbl-internal-extras

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>