### PR TITLE
Add restricted extras layer to BBLAYERS if it exists

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -39,6 +39,9 @@ BBLAYERS = " \
   ${OEROOT}/layers/openembedded-core/meta \
 "
 
+# allow meta-mbl-restricted-extras to add itself to BBLAYERS, if present
+include ${OEROOT}/layers/meta-mbl-restricted-extras/conf/bblayers.conf
+
 # allow meta-mbl-internal-extras to add itself to BBLAYERS, if present
 include ${OEROOT}/layers/meta-mbl-internal-extras/conf/bblayers.conf
 


### PR DESCRIPTION
For:
IOTMBL-257: Add mbl-cloud-client to meta-mbl-restricted-extras using
mbed-cloud-client-restricted

There's a new meta-mbl-restricted-extras layer that is optional for Mbed
Linux, so add it to BBLAYERS only if it exists.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>