### PR TITLE
Remove unnecessary append of IMAGE_FSTYPES

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -5,10 +5,6 @@ CONF_VERSION = "1"
 # Which files do we want to parse:
 BBMASK = ""
 
-# What kind of images do we want?
-# Use the defaults provided by mbl.conf
-# IMAGE_FSTYPES_append = " tar.xz"
-
 # Don't generate the mirror tarball for SCM repos, the snapshot is enough
 BB_GENERATE_MIRROR_TARBALLS = "0"
 


### PR DESCRIPTION
For:
IOTMBL-156: Remove rpi-sdimg from IMAGE_FSTYPES

IOTMBL-91: Be consistent about what type of rootfs images we create

IOTMBL-133: Support writing mbl disk images to flash faster by taking
advantage of image sparseness

mbl.conf in meta-mbl has been changed to set IMAGE_FSTYPES to just the
image types we need for mbl so this append to IMAGE_FSTYPES is no longer
required.