### PR TITLE
Add meta-mbl-reference-apps-internal to BBLAYERS if it exists

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -47,3 +47,6 @@ include ${OEROOT}/layers/meta-mbl-internal-extras/conf/bblayers.conf
 
 # allow meta-mbl-reference-apps to add itself to BBLAYERS, if present
 include ${OEROOT}/layers/meta-mbl-reference-apps/conf/bblayers.conf
+
+# allow meta-mbl-reference-apps-internal to add itself to BBLAYERS, if present
+include ${OEROOT}/layers/meta-mbl-reference-apps-internal/conf/bblayers.conf


### PR DESCRIPTION
For:
IOTMBL-332: Create a reference apps repo for example trusted apps

We now have a meta-mbl-reference-apps-internal layer. Add it to BBLAYERS
if it exists in the work area.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>