### PR TITLE
Add Allwinner sunxi layer to support bananapi-zero

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -21,6 +21,7 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-freescale-3rdparty \
   ${OEROOT}/layers/meta-raspberrypi \
+  ${OEROOT}/layers/meta-sunxi \
 "
 
 # Add your overlay location to EXTRALAYERS


### PR DESCRIPTION
This  PR just add sunxi layer to bblayer config so that it can be included by yocoto.

Signed-off-by: Jun Nie <jun.nie@linaro.org>