### PR TITLE
IOTMBL-401: Revert "Add Allwinner sunxi layer to support bananapi-zero"

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -21,7 +21,6 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-freescale-3rdparty \
   ${OEROOT}/layers/meta-raspberrypi \
-  ${OEROOT}/layers/meta-sunxi \
 "
 
 # Add your overlay location to EXTRALAYERS


### PR DESCRIPTION
This reverts commit 96b0482060c584eaf1e95da07552911334f57333.
The change was made in preparation for the delivery of the
bananapi-zero bsp, but this has now been deferred.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>