### PR TITLE
Add vars used by mbl-cloud-client to BB_ENV_EXTRAWHITE

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -158,7 +158,7 @@ export PATH="${OEROOT}"/layers/openembedded-core/scripts:"${OEROOT}"/bitbake/bin
 export PATH=$(echo "$PATH" | awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' | sed 's/:$//')
 # Make sure Bitbake doesn't filter out the following variables from our
 # environment. Including allowing for a shared download directory (DL_DIR)
-export BB_ENV_EXTRAWHITE="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMMAND http_proxy ftp_proxy https_proxy all_proxy ALL_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY SDKMACHINE BB_NUMBER_THREADS DL_DIR"
+export BB_ENV_EXTRAWHITE="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMMAND http_proxy ftp_proxy https_proxy all_proxy ALL_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY SDKMACHINE BB_NUMBER_THREADS DL_DIR MBED_CLOUD_IDENTITY_CERT_FILE MBED_UPDATE_RESOURCE_FILE"
 
 # Helper command for building images for mixed 32bit/64bit
 # ARM builds. The command allow to specify a secondary MACHINE


### PR DESCRIPTION
For:
IOTMBL-126: Fix mechanism for specifying cloud & update credentials from
environment variables

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>