### PR TITLE
Add package management tools support into the image

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -12,6 +12,10 @@ BB_GENERATE_MIRROR_TARBALLS = "0"
 # and wait for manual intervention. We disable it.
 PATCHRESOLVE = "noop"
 
+#additional features to include in an image - 
+#installs package management tools and preserves the package manager database
+EXTRA_IMAGE_FEATURES = "package-management"
+
 #
 # Parallelism Options
 #


### PR DESCRIPTION
The added line in local.conf tells the build system to include package management tools on the target.
It installs package management tools and preserves the package manager database.
This is needed by the opkg package manager.