### PR TITLE
Add issue template for Github issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -26,6 +26,7 @@
     - What is the SHA of mbl-manifest or any other relevant repository? (git log -n1 --oneline)?
     - Can you provide a pinned manifest?
     - What are the steps to reproduce the issue?
+    - Attach any log which may help with the issue resolution
 -->
 
 


### PR DESCRIPTION
This template is used for our internal bot in order to sync github
issues with Jira issues.