### PR TITLE
Remove unused BB_ENV_EXTRAWHITE values

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -133,7 +133,7 @@ export PATH="${OEROOT}"/layers/openembedded-core/scripts:"${OEROOT}"/bitbake/bin
 export PATH=$(echo "$PATH" | awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' | sed 's/:$//')
 # Make sure Bitbake doesn't filter out the following variables from our
 # environment. Including allowing for a shared download directory (DL_DIR)
-export BB_ENV_EXTRAWHITE="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMMAND http_proxy ftp_proxy https_proxy all_proxy ALL_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY SDKMACHINE BB_NUMBER_THREADS DL_DIR MBED_CLOUD_IDENTITY_CERT_FILE MBED_UPDATE_RESOURCE_FILE"
+export BB_ENV_EXTRAWHITE="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMMAND http_proxy ftp_proxy https_proxy all_proxy ALL_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY SDKMACHINE BB_NUMBER_THREADS DL_DIR"
 
 # Helper command for building images for mixed 32bit/64bit
 # ARM builds. The command allow to specify a secondary MACHINE


### PR DESCRIPTION
We no longer build update and cloud credentials into mbl-cloud-client so
there's no longer a need to specify where these credentials are in
environment variables. Remove those environment variables from
BB_ENV_EXTRAWHITE.

**Related PRs**
https://github.com/ARMmbed/mbl-core/pull/86 (must be merged before this PR)
https://github.com/ARMmbed/meta-mbl/pull/379 (must be merged before this PR)

**Jenkins links**
To come once we start testing after RobW's provisioning PRs are merged.

**Testing to do**
Basic boot test on a single platform should be fine. To be done once we start testing after RobW's provisioning PRs are merged.