### PR TITLE
Don't accept EULA by default and add mechanisms for the user to accept (#33)

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -52,8 +52,6 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # generating the feeds
 #PRSERV_HOST = "localhost:0"
 
-ACCEPT_FSL_EULA = "1"
-
 # Override default FETCHCMD_wget with increased timeout parameters
 # -t: number of tries (default was 2)
 # -T: network timeout in seconds (default was 30)

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -3,12 +3,12 @@
 #
 # Based on: setup-environment-internal
 # In open-source project: https://github.com/96boards/oe-rpb-manifest
-# 
+#
 # Original file: Copyright (C) 2012-13 O.S. Systems Software LTDA.
-# Modifications: Copyright (c) 2018 Arm Limited and Contributors. All rights reserved.
+# Modifications: Copyright (c) 2018-2019 Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-2.0-only
-# 
+#
 # Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
 # Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
 #
@@ -25,6 +25,134 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+
+# Handle EULA if needed.
+#
+# We assume that there can only be a single EULA for the current MACHINE and
+# that the EULA can be accepted by writing a value to a BitBake variable in the
+# config (auto.conf).
+#
+# If we find a EULA for the current MACHINE then, by default, we prompt the
+# user to accept the EULA, and if they accept, we record this by setting a
+# BitBake variable to some value.
+#
+# Alternatively, this script will automatically accept the EULA for a MACHINE
+# if the environment variable ACCEPT_EULA_${MACHINE_STR} is non-empty, where
+# ${MACHINE_STR} is the name of the MACHINE with all hyphens and the "-mbl"
+# suffix removed.
+#
+# The location of the EULA, the name of the BitBake variable and the value to
+# write to that variable are, in general, MACHINE (or at least BSP) dependent.
+# The "case" statement below is used to define these three things for each
+# MACHINE.
+#
+# The default case is a general pattern for EULA path, BitBake variable, and
+# value that was used by this script before it was adopted by MBL OS. This
+# scheme is used by e.g. meta-qcom.
+#
+# The proper OE way of dealing with commercial licenses and EULAs (using
+# LICENSE_FLAGS and LICENSE_FLAGS_WHITELIST) is not supported here - MBL OS
+# does not yet support any MACHINES with BSPs that use LICENSE_FLAGS, and in
+# any case, it would be difficult to actually find the relevant EULAs and
+# accept them before starting a build.
+#
+# FIXME: there is a potential issue if the same $MACHINE is set in more than
+# one layer.. but we should assert that earlier
+mbl_eula_handle () {
+    NON_MBL_MACHINE="${MACHINE%-mbl}"
+
+    # remove '-' since we are constructing an environment variable name here
+    EULA_ACCEPT_ENV_VAR="$(echo "ACCEPT_EULA_${NON_MBL_MACHINE}" | sed 's/-//g')"
+
+    case "$NON_MBL_MACHINE" in
+        # MBL OS also supports imx7s-warp and imx7d-pico from meta-freescale, but
+        # we don't use recipes for those MACHINEs that require acceptance of a
+        # EULA. If we start using recipes covered by a EULA without updating this
+        # code then those recipes will fail to build due to the missing
+        # ACCEPT_FSL_EULA variable.
+    imx8mmevk)
+        EULA_PATH="../layers/meta-freescale/EULA"
+        EULA_ACCEPT_BB_VAR="ACCEPT_FSL_EULA"
+        EULA_ACCEPT_BB_VALUE="1"
+        ;;
+    *)
+        EULA_PATH=$(find ../layers -path "*/conf/eula/${NON_MBL_MACHINE}" -print | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
+        EULA_ACCEPT_BB_VAR="ACCEPT_EULA_${NON_MBL_MACHINE}"
+        EULA_ACCEPT_BB_VALUE="1"
+        ;;
+    esac
+
+    if [ -n "$EULA_PATH" ]; then
+
+        # Check if the EULA has already been accepted before
+        if [ ! -f "${EULA_ACCEPT_ENV_VAR}" ]; then
+            # NOTE: indirect reference / dynamic variable
+            if [ -n "${!EULA_ACCEPT_ENV_VAR}" ]; then
+                # The EULA_ACCEPT_ENV_VAR variable is set in the environment, so we
+                # just configure EULA_ACCEPT_BB_VAR in auto.conf and remove any previous
+                # occurrence
+                sed -i "/${EULA_ACCEPT_BB_VAR}/d" conf/auto.conf
+                echo "${EULA_ACCEPT_BB_VAR} = \"${EULA_ACCEPT_BB_VALUE}\"" >> conf/auto.conf
+                # Create a file to indicate that the EULA was already accepted
+                touch "${EULA_ACCEPT_ENV_VAR}"
+            else
+                # so we need to ask user if he/she accepts the EULA:
+                cat <<EOF
+
+The BSP for $NON_MBL_MACHINE depends on packages and firmware which are covered by an End
+User License Agreement (EULA). To have the right to use these binaries
+in your images, you need to read and accept the following...
+
+EOF
+
+                echo
+                REPLY=
+                while [ -z "$REPLY" ]; do
+                    echo -n "Would you like to read the EULA ? (y/n) "
+                    read -r REPLY
+                    case "$REPLY" in
+                        y|Y)
+                            READ_EULA=1
+                            ;;
+                        n|N)
+                            READ_EULA=0
+                            ;;
+                        *)
+                            REPLY=
+                            ;;
+                    esac
+                done
+
+                if [ "$READ_EULA" = 1 ]; then
+                    more -d "${EULA_PATH}"
+                    echo
+                    REPLY=
+                    while [ -z "$REPLY" ]; do
+                        echo -n "Do you accept the EULA you just read? (y/n) "
+                        read -r REPLY
+                        case "$REPLY" in
+                            y|Y)
+                                echo "EULA has been accepted."
+                                sed -i "/${EULA_ACCEPT_BB_VAR}/d" conf/auto.conf
+                                echo "${EULA_ACCEPT_BB_VAR} = \"${EULA_ACCEPT_BB_VALUE}\"" >> conf/auto.conf
+                                # Create a file to indicate that the EULA was already accepted
+                                touch "${EULA_ACCEPT_ENV_VAR}"
+                                ;;
+                            n|N)
+                                echo "EULA has not been accepted."
+                                sed -i "/${EULA_ACCEPT_BB_VAR}/d" conf/auto.conf
+                                ;;
+                            *)
+                                REPLY=
+                                ;;
+                        esac
+                    done
+                fi
+            fi
+        fi
+    fi
+}
+
 RPBcleanup() {
         unset MACHINETABLE MACHLAYERS DISTRO_DIRNAME OEROOT
         unset ITEM MANIFESTS EULA EULA_MACHINE REPLY READ_EULA
@@ -198,8 +326,13 @@ mkdir -p "${BUILDDIR}"/conf && cd "${BUILDDIR}"
 if [ -f "conf/auto.conf" ]; then
     oldmach=$(egrep "^MACHINE" "conf/auto.conf" | sed -e 's%^MACHINE ?= %%' | sed -e 's/^"//'  -e 's/"$//')
 fi
+
 if [ -e conf/checksum -a "${MACHINE}" = "$oldmach" ]
 then
+    # Even for the case we do not need to perform the setup for
+    # the first build we still need to check if the EULA needs
+    # to be accepted
+    mbl_eula_handle
     sha512sum --quiet -c conf/checksum > /dev/null 2>&1
     if [ $? -eq 0 ]
     then
@@ -226,6 +359,9 @@ SDKMACHINE ?= "${SDKMACHINE}"
 # Extra options that can be changed by the user
 INHERIT += "rm_work"
 EOF
+
+mbl_eula_handle
+
 if [ ! -e conf/site.conf ]; then
     cat > conf/site.conf <<_EOF
 
@@ -243,79 +379,6 @@ TMPDIR = "${BUILDDIR}/tmp-${DISTRO_DIRNAME}"
 #HTTP_PROXY        = "http://${PROXYHOST}:${PROXYPORT}/"
 
 _EOF
-fi
-
-# Handle EULA , if needed. This is a generic method to handle BSPs
-# that might (or not) come with a EULA. If a machine has a EULA, we
-# assume that its corresponding layers has conf/EULA/$MACHINE file
-# with the EULA text, which we will display to the user and request
-# for acceptance. If accepted, the variable ACCEPT_EULA_$MACHINE is
-# set to 1 in auto.conf, which can later be used by the BSP.
-# If the env variable EULA_$MACHINE is set it is used by default,
-# without prompting the user.
-# FIXME: there is a potential issue if the same $MACHINE is set in more than one layer.. but we should assert that earlier
-EULA=$(find ../layers -path "*/conf/eula/$MACHINE" -print | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
-
-if [ -n "$EULA" ]; then
-
-    # remove '-' since we are constructing a bash variable name here
-    EULA_MACHINE="EULA_$(echo "$MACHINE" | sed 's/-//g')"
-
-    # NOTE: indirect reference / dynamic variable
-    if [ -n "${!EULA_MACHINE}" ]; then
-        # the EULA_$MACHINE variable is set in the environment, so we just configure
-        # ACCEPT_EULA_$MACHINE in auto.conf
-        echo "ACCEPT_EULA_$MACHINE = \"${!EULA_MACHINE}\"" >> conf/auto.conf
-    else
-        # so we need to ask user if he/she accepts the EULA:
-        cat <<EOF
-
-The BSP for $MACHINE depends on packages and firmware which are covered by an End
-User License Agreement (EULA). To have the right to use these binaries
-in your images, you need to read and accept the following...
-
-EOF
-
-        echo
-        REPLY=
-        while [ -z "$REPLY" ]; do
-            echo -n "Would you like to read the EULA ? (y/n) "
-            read -r REPLY
-            case "$REPLY" in
-                y|Y)
-                    READ_EULA=1
-                    ;;
-                n|N)
-                    READ_EULA=0
-                    ;;
-                *)
-                    REPLY=
-                    ;;
-            esac
-        done
-
-        if [ "$READ_EULA" = 1 ]; then
-            more -d "${EULA}"
-            echo
-            REPLY=
-            while [ -z "$REPLY" ]; do
-                echo -n "Do you accept the EULA you just read? (y/n) "
-                read -r REPLY
-                case "$REPLY" in
-                    y|Y)
-                        echo "EULA has been accepted."
-                        echo "ACCEPT_EULA_$MACHINE = \"1\"" >> conf/auto.conf
-                        ;;
-                    n|N)
-                        echo "EULA has not been accepted."
-                        ;;
-                    *)
-                        REPLY=
-                        ;;
-                esac
-            done
-        fi
-    fi
 fi
 
 cat <<EOF


### PR DESCRIPTION
* Don't accept EULA by default and add mechanisms for the user to accept

Previously we were accepting the FSL EULA by default in the local.conf
file.

We changed this behavior by allowing the user to either accept
automatically by exporting an environment variable with
ACCEPT_EULA_${MACHINE_STR} pattern or by displaying the EULA in the
screen and capture the user confirmation manually.

The acceptance just needs to be done one time.

Fixes IOTMBL-1751: Fix EULAs in MBL build and for evaluation binaries

Backport of PR #33 