### PR TITLE
IOTMBL-1984: Update bblayers.conf for meta-mbl new meta-layer restruc…

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -20,29 +20,38 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
   ${OEROOT}/layers/meta-openembedded/meta-networking \
   ${OEROOT}/layers/meta-openembedded/meta-oe \
+  ${OEROOT}/layers/meta-mbl/meta-openembedded-mbl/meta-oe-mbl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-virtualization \
+  ${OEROOT}/layers/meta-mbl/meta-virtualization-mbl \
 "
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
+  ${OEROOT}/layers/meta-mbl/meta-mbl-bsp-common \
   ${OEROOT}/layers/meta-freescale \
+  ${OEROOT}/layers/meta-mbl/meta-freescale-mbl \
   ${OEROOT}/layers/meta-freescale-3rdparty \
+  ${OEROOT}/layers/meta-mbl/meta-freescale-3rdparty-mbl \
   ${OEROOT}/layers/meta-raspberrypi \
+  ${OEROOT}/layers/meta-mbl/meta-raspberrypi-mbl \
 "
 
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-optee \
+  ${OEROOT}/layers/meta-mbl/meta-linaro-mbl/meta-optee-mbl \
 "
 
 BBLAYERS = " \
-  ${OEROOT}/layers/meta-mbl \
+  ${OEROOT}/layers/meta-mbl/meta-mbl-distro \
+  ${OEROOT}/layers/meta-mbl/meta-mbl-apps \
   ${BASELAYERS} \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \
   ${OEROOT}/layers/openembedded-core/meta \
+  ${OEROOT}/layers/meta-mbl/openembedded-core-mbl/meta \
 "
 
 # allow meta-mbl-restricted-extras to add itself to BBLAYERS, if present


### PR DESCRIPTION
…turing.

The following provides more information on this commit:
- The meta-mbl layer has been restructured into a number of new layers
  to facilate component re-use.
- The following new meta-layers have been added to meta-mbl:
  - meta-openembedded-mbl/meta-oe-mbl, for meta-openembedded/meta-oe
    meta-data and recipes.
  - meta-virtualization-mbl, for meta-virtualization meta-data and
    recipes relating to containerd, docker, runc for example.
  - meta-mbl-bsp-common, for meta-data and recipes used by multiple
    meta-[soc-vendor] BSP layers.
  - meta-freescale-mbl, for meta-freescale meta-data and recipes e.g.
    imx8mmevk-mbl meta-data.
  - meta-freescale-3rdparty-mbl, for meta-freescale-3rdparty meta-data
    and recipes, e.g. imx7s-warp-mbl and imx7d-pico-mbl meta-data.
  - meta-raspberrypi-mbl, for meta-raspberrypi meta-data and recipes, e.g.
    for raspberrypi3-mbl meta-data.
  - meta-linaro-mbl/meta-optee-mbl, for meta-linaro/meta-optee
    meta-data and recipes, e.g. for OPTEE related meta-data.
  - meta-mbl-distro, the MBL distribution layer for distribution
    config, image recipes, packagegroups, WKS files and related meta-data.
  - meta-mbl-apps, for MBL applications including mbl-cloud-client
    meta-data and recipes.
  - openembedded-core-mbl/meta, for openembedded-core/meta related
    meta-data and recipes.
- The above new meta-layers have been added to bblayers.conf.
- The MBL old distro layer meta-mbl has been removed from bblayers.conf, as
  meta-mbl-distro now serves the role of the distro meta-layer.

The following PRs should be synchronised and merged together.

https://github.com/ARMmbed/meta-mbl/pull/478
https://github.com/ARMmbed/mbl-config/pull/37
https://github.com/ARMmbed/mbl-tools/pull/186
