### PR TITLE
Add EULA acceptance for imx7d-pico-mbl

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -77,6 +77,11 @@ mbl_eula_handle () {
         EULA_ACCEPT_BB_VAR="ACCEPT_FSL_EULA"
         EULA_ACCEPT_BB_VALUE="1"
         ;;
+    imx7d-pico)
+        EULA_PATH="../layers/meta-fsl-bsp-release/imx/EULA.txt"
+        EULA_ACCEPT_BB_VAR="ACCEPT_FSL_EULA"
+        EULA_ACCEPT_BB_VALUE="1"
+        ;;
     *)
         EULA_PATH=$(find ../layers -path "*/conf/eula/${NON_MBL_MACHINE}" -print | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
         EULA_ACCEPT_BB_VAR="ACCEPT_EULA_${NON_MBL_MACHINE}"


### PR DESCRIPTION
Fixes: IOTMBL-2020: Add EULA acceptance prompt to imx7d-pico-mbl machine
Jira: https://jira.arm.com/browse/IOTMBL-2020
Jenkins: http://jenkins.mbed-linux.arm.com/job/ds-test/59/
Sync:https://github.com/ARMmbed/mbl-tools/pull/196