### PR TITLE
Add meta-fsl-bsp-release layer

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -35,6 +35,7 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-mbl/meta-freescale-3rdparty-mbl \
   ${OEROOT}/layers/meta-raspberrypi \
   ${OEROOT}/layers/meta-mbl/meta-raspberrypi-mbl \
+  ${OEROOT}/layers/meta-fsl-bsp-release/imx/meta-bsp \
 "
 
 # Add your overlay location to EXTRALAYERS


### PR DESCRIPTION
Add meta-fsl-bsp-release layer to get kernel-module recipe for
qca9377 wifi feature.
EULA license check for meta-fsl-bsp-release layer is not added
to unblock jenkins build. It will be added by Diego later.

Signed-off-by: Jun Nie <jun.nie@linaro.org>