### PR TITLE
IOTMBL-1991: Add meta-fsl-bsp-release layer

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -35,6 +35,7 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-mbl/meta-freescale-3rdparty-mbl \
   ${OEROOT}/layers/meta-raspberrypi \
   ${OEROOT}/layers/meta-mbl/meta-raspberrypi-mbl \
+  ${OEROOT}/layers/meta-fsl-bsp-release/imx/meta-bsp \
 "
 
 # Add your overlay location to EXTRALAYERS


### PR DESCRIPTION
Add meta-fsl-bsp-release layer to include qca9377 recipe for WiFi.

Signed-off-by: Jun Nie <jun.nie@linaro.org>