### PR TITLE
IOTMBL-1959: Remove meta-openembedded-mbl/meta-oe-mbl layer from bblayers.conf

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -20,7 +20,6 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
   ${OEROOT}/layers/meta-openembedded/meta-networking \
   ${OEROOT}/layers/meta-openembedded/meta-oe \
-  ${OEROOT}/layers/meta-mbl/meta-openembedded-mbl/meta-oe-mbl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-mbl/meta-virtualization-mbl \


### PR DESCRIPTION
The following provides more information on this commit:
- The meta-openembedded-mbl/meta-oe-mbl layer was introduced as part of the
  meta-mbl layer restructuring to accomodate some recipes and/or meta-data.
  These items have since been moved to other locations so this layer
  is now empty.
- An empty layer included in bblayers.conf generates an unwanted warning.
  To fix the warning, the layer is removed from the meta-mbl repository.
- This commit removes the meta-openembedded-mbl/meta-oe-mbl layer from
  bblayers.conf.
- This commit should be accepted into mbl-config proir to the removal of the
  layer from meta-mbl.

This PR should be merged before the following related PR:

https://github.com/ARMmbed/meta-mbl/pull/538

Test job available here:

http://jenkins.mbed-linux.arm.com/view/simon/job/sdh-mbl-master2/119/console

