### PR TITLE
IOTMBL-1959: Rename openembedded-core-mbl/meta to meta-mbl in bblayer.conf

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -46,7 +46,7 @@ BBLAYERS = " \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \
   ${OEROOT}/layers/openembedded-core/meta \
-  ${OEROOT}/layers/meta-mbl/openembedded-core-mbl/meta \
+  ${OEROOT}/layers/meta-mbl/openembedded-core-mbl/meta-mbl \
 "
 
 # allow meta-mbl-restricted-extras to add itself to BBLAYERS, if present


### PR DESCRIPTION
The following provides more information on this commit:
- The convention for naming meta-mbl staging layers for
  community meta-layers is to append '-mbl' to the end
  of the layer name. If the layer is a subdirectory
  in a repository which contains multiple layers then
  the convention is to also to append '-mbl' to the
  end of the repository name (which appears as the
  containing directory for the meta-layer in the
  MBL workspace).
- To follow the convention outlined in the preceding point,
  openembedded-core-mbl/meta is renamed to openembedded-core-mbl/meta-mbl
  in the meta-mbl repo.
- This commit modifies bblayers.conf to rename openembedded-core-mbl/meta
  to meta-mbl in bblayers.conf.


The following Jenkins test job has been initiated:
http://jenkins.mbed-linux.arm.com/view/simon/job/sdh-mbl-master2/137/console

Sync with: 

https://github.com/ARMmbed/meta-mbl/pull/551
