### PR TITLE
layers: apply new naming convention for 3rd party layers customization

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -36,7 +36,7 @@ BSPLAYERS ?= " \
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-optee \
-  ${OEROOT}/layers/meta-mbl/meta-linaro-mbl/meta-optee-mbl \
+  ${OEROOT}/layers/meta-mbl/meta-linaro-mbl/meta-optee \
 "
 
 BBLAYERS = " \


### PR DESCRIPTION
This patch applies the new convention for naming 3rd party layers
customization directories. Now the "-mbl" string should be appended
only in the repository directory name and not in the meta layer
directory. Some cases the repository directory is the meta layer
directory.

**Jenkins:** http://jenkins.mbed-linux.arm.com/job/ds-warrior-dev/28/
**Sync merge:** https://github.com/ARMmbed/meta-mbl/pull/554