### PR TITLE
bblayers: Change the parsing order for the staging layers

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -21,8 +21,8 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-networking \
   ${OEROOT}/layers/meta-openembedded/meta-oe \
   ${OEROOT}/layers/meta-openembedded/meta-python \
-  ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-mbl/meta-virtualization-mbl \
+  ${OEROOT}/layers/meta-virtualization \
 "
 
 # Specify the BSP layers that are used for all supported targets.
@@ -35,8 +35,8 @@ BSPLAYERS ?= " \
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
-  ${OEROOT}/layers/meta-linaro/meta-optee \
   ${OEROOT}/layers/meta-mbl/meta-linaro-mbl/meta-optee \
+  ${OEROOT}/layers/meta-linaro/meta-optee \
 "
 
 BBLAYERS = " \
@@ -45,8 +45,8 @@ BBLAYERS = " \
   ${BASELAYERS} \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \
-  ${OEROOT}/layers/openembedded-core/meta \
   ${OEROOT}/layers/meta-mbl/openembedded-core-mbl/meta \
+  ${OEROOT}/layers/openembedded-core/meta \
 "
 
 # allow meta-mbl-restricted-extras to add itself to BBLAYERS, if present

--- a/bblayers_imx7d-pico-mbl.conf
+++ b/bblayers_imx7d-pico-mbl.conf
@@ -11,10 +11,10 @@
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS += " \
-  ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-mbl/meta-freescale-mbl \
-  ${OEROOT}/layers/meta-freescale-3rdparty \
+  ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-mbl/meta-freescale-3rdparty-mbl \
+  ${OEROOT}/layers/meta-freescale-3rdparty \
   ${OEROOT}/layers/meta-mbl/meta-fsl-bsp-release-mbl/imx/meta-bsp \
   ${OEROOT}/layers/meta-fsl-bsp-release/imx/meta-bsp \
 "

--- a/bblayers_imx7s-warp-mbl.conf
+++ b/bblayers_imx7s-warp-mbl.conf
@@ -8,8 +8,8 @@
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS += " \
-  ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-mbl/meta-freescale-mbl \
-  ${OEROOT}/layers/meta-freescale-3rdparty \
+  ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-mbl/meta-freescale-3rdparty-mbl \
+  ${OEROOT}/layers/meta-freescale-3rdparty \
 "

--- a/bblayers_imx8mmevk-mbl.conf
+++ b/bblayers_imx8mmevk-mbl.conf
@@ -11,8 +11,8 @@
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS += " \
-  ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-mbl/meta-freescale-mbl \
-  ${OEROOT}/layers/meta-fsl-bsp-release/imx/meta-bsp \
+  ${OEROOT}/layers/meta-freescale \
   ${OEROOT}/layers/meta-mbl/meta-fsl-bsp-release-mbl/imx/meta-bsp \
+  ${OEROOT}/layers/meta-fsl-bsp-release/imx/meta-bsp \
 "

--- a/bblayers_raspberrypi3-mbl.conf
+++ b/bblayers_raspberrypi3-mbl.conf
@@ -9,6 +9,6 @@
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS += " \
-  ${OEROOT}/layers/meta-raspberrypi \
   ${OEROOT}/layers/meta-mbl/meta-raspberrypi-mbl \
+  ${OEROOT}/layers/meta-raspberrypi \
 "


### PR DESCRIPTION
To be able to customize the layer.conf variables of the upstream layers
in the mbl staging layers we need to change the parsing order and have
the mbl staging to be parsed first.