### PR TITLE
imx6ull-pico-mbl: Add imx6ull config

### DIFF
--- a/bblayers_imx6ul-pico-mbl.conf
+++ b/bblayers_imx6ul-pico-mbl.conf
@@ -1,0 +1,20 @@
+# Based on: conf/bblayers.conf
+# In open-source project: https://github.com/96boards/oe-rpb-manifest
+#
+# Original file: Copyright (c) 2013 Khem Raj
+# Modifications: Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+
+# SPDX-License-Identifier: MIT
+
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+
+# These layers hold machine specific content, aka Board Support Packages
+BSPLAYERS += " \
+  ${OEROOT}/layers/meta-mbl/meta-freescale-mbl \
+  ${OEROOT}/layers/meta-freescale \
+  ${OEROOT}/layers/meta-mbl/meta-freescale-3rdparty-mbl \
+  ${OEROOT}/layers/meta-freescale-3rdparty \
+  ${OEROOT}/layers/meta-mbl/meta-fsl-bsp-release-mbl/imx/meta-bsp \
+  ${OEROOT}/layers/meta-fsl-bsp-release/imx/meta-bsp \
+"

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -72,7 +72,7 @@ mbl_eula_handle () {
         # EULA. If we start using recipes covered by a EULA without updating this
         # code then those recipes will fail to build due to the missing
         # ACCEPT_FSL_EULA variable.
-    imx8mmevk|imx7d-pico)
+    imx8mmevk|imx7d-pico|imx6ul-pico)
         EULA_PATH="../layers/meta-fsl-bsp-release/imx/EULA.txt"
         EULA_ACCEPT_BB_VAR="ACCEPT_FSL_EULA"
         EULA_ACCEPT_BB_VALUE="1"


### PR DESCRIPTION
Adds in support for building i.MX6ULL.

Test this out with the following changes to default.xml

```
<project name="armmbed/mbl-config" path="conf" remote="github" revision="warrior-dev+imx6ull">
<project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" revision="warrior-dev+imx6ull"/>

```