### PR TITLE
meta-beaglebone-mbl: Enable beaglebone boards

### DIFF
--- a/bblayers_beaglebone-mbl.conf
+++ b/bblayers_beaglebone-mbl.conf
@@ -1,0 +1,15 @@
+# Based on: conf/bblayers.conf
+# In open-source project: https://github.com/96boards/oe-rpb-manifest
+# 
+# Original file: Copyright (c) 2013 Khem Raj
+# Modifications: Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+ 
+# SPDX-License-Identifier: MIT
+
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+
+# These layers hold machine specific content, aka Board Support Packages
+BSPLAYERS += " \
+  ${OEROOT}/layers/meta-mbl/meta-beagleboard-mbl \
+"


### PR DESCRIPTION
IOTMBL-2186: BeagelBone Enhanced BSP only - add machine and bblayers

This commit adds beaglebone BSP.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>