### PR TITLE
Add meta-selinux to fix FTBFS of virtualization-layer

### DIFF
--- a/bblayers.conf
+++ b/bblayers.conf
@@ -23,6 +23,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-mbl/meta-virtualization-mbl \
   ${OEROOT}/layers/meta-virtualization \
+  ${OEROOT}/layers/meta-selinux \
 "
 
 # Specify the BSP layers that are used for all supported targets.


### PR DESCRIPTION
IOTMBL-2372: mbl-master: build broken because of missing sellinux layer.

This commit add meta-selinux to fix the FTBFS of virtualization-layer.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>