### PR TITLE
setup-environment: Add meta-mbl-distro/scripts to PATH

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -271,7 +271,7 @@ BUILDDIR=$OEROOT/$BUILDDIR
 # Clean up PATH, because if it includes tokens to current directories somehow,
 # wrong binaries can be used instead of the expected ones during task execution
 export PATH=$(echo "${PATH}" | sed 's/\(:.\|:\)*:/:/g;s/^.\?://;s/:.\?$//')
-export PATH="${OEROOT}"/layers/openembedded-core/scripts:"${OEROOT}"/bitbake/bin:"${OEROOT}"/.repo/repo:"${PATH}"
+export PATH="${OEROOT}"/layers/openembedded-core/scripts:"${OEROOT}"/layers/meta-mbl/meta-mbl-distro/scripts:"${OEROOT}"/bitbake/bin:"${OEROOT}"/.repo/repo:"${PATH}"
 #remove duplicate path entries
 export PATH=$(echo "$PATH" | awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' | sed 's/:$//')
 # Make sure Bitbake doesn't filter out the following variables from our


### PR DESCRIPTION
It seems appropriate to add the meta-mbl-distro/scripts dir to PATH
as we want the create-update-payload (and possibly other future scripts)
to be available in the MBL environment.

Jenkins: http://jenkins.mbed-linux.arm.com/job/rw-test/143/