### PR TITLE
local.conf: Don't let SSH_AUTH_SOCK affect task hashes

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -57,3 +57,7 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # -T: network timeout in seconds (default was 30)
 # The rest of the parameters are the same.
 FETCHCMD_wget = "/usr/bin/env wget -t 10 -T 90 -nv --passive-ftp --no-check-certificate"
+
+export SSH_AUTH_SOCK
+BB_HASHBASE_WHITELIST_append = " SSH_AUTH_SOCK"
+BB_HASHCONFIG_WHITELIST_append = " SSH_AUTH_SOCK"


### PR DESCRIPTION
1. Export SSH_AUTH_SOCK so that recipes can use ssh-agent based SSH in
   any tasks.
2. Ensure that the value of SSH_AUTH_SOCK doesn't affect task base
   hashes - it shouldn't make any difference to build artifacts.

**Jenkins builds**
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/184/ (with changes from https://github.com/ARMmbed/mbl-tools/pull/359).
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/186/ (with changes from https://github.com/ARMmbed/mbl-tools/pull/359 and changes from https://github.com/ARMmbed/meta-mbl/pull/777).

**Related PRs**
* https://github.com/ARMmbed/mbl-tools/pull/359 (set up SSH consistently in build containers)
* https://github.com/ARMmbed/meta-mbl/pull/777 (don't `export SSH_AUTH_SOCK` in mbl-cloud-client recipe).