### PR TITLE
zeus-dev: sync up with warrior-dev

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -57,3 +57,7 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # -T: network timeout in seconds (default was 30)
 # The rest of the parameters are the same.
 FETCHCMD_wget = "/usr/bin/env wget -t 10 -T 90 -nv --passive-ftp --no-check-certificate"
+
+export SSH_AUTH_SOCK
+BB_HASHBASE_WHITELIST_append = " SSH_AUTH_SOCK"
+BB_HASHCONFIG_WHITELIST_append = " SSH_AUTH_SOCK"


### PR DESCRIPTION
2019-11-13 63e859f local.conf: Don't let SSH_AUTH_SOCK affect task hashes (#65)